### PR TITLE
modulus and publicExponent index

### DIFF
--- a/lib/ex_public_key/ex_rsa_private_key.ex
+++ b/lib/ex_public_key/ex_rsa_private_key.ex
@@ -1,8 +1,8 @@
 defmodule ExPublicKey.RSAPrivateKey do
 
   defstruct version: nil,
-            public_exponent: nil,
             public_modulus: nil,
+            public_exponent: nil,
             private_exponent: nil,
             prime_one: nil,
             prime_two: nil,
@@ -13,8 +13,8 @@ defmodule ExPublicKey.RSAPrivateKey do
 
   @type t :: %ExPublicKey.RSAPrivateKey{
     version: atom,
-    public_exponent: integer,
     public_modulus: integer,
+    public_exponent: integer,
     private_exponent: integer,
     prime_one: integer,
     prime_two: integer,
@@ -27,8 +27,8 @@ defmodule ExPublicKey.RSAPrivateKey do
   def from_sequence(rsa_key_seq) do
     %ExPublicKey.RSAPrivateKey{} |> struct(
       version: elem(rsa_key_seq, 1),
-      public_exponent: elem(rsa_key_seq, 2),
-      public_modulus: elem(rsa_key_seq, 3),
+      public_modulus: elem(rsa_key_seq, 2),
+      public_exponent: elem(rsa_key_seq, 3),
       private_exponent: elem(rsa_key_seq, 4),
       prime_one: elem(rsa_key_seq, 5),
       prime_two: elem(rsa_key_seq, 6),
@@ -45,8 +45,8 @@ defmodule ExPublicKey.RSAPrivateKey do
         {:ok, {
           :RSAPrivateKey,
           rsa_private_key.version,
-          rsa_private_key.public_exponent,
           rsa_private_key.public_modulus,
+          rsa_private_key.public_exponent,
           rsa_private_key.private_exponent,
           rsa_private_key.prime_one,
           rsa_private_key.prime_two,

--- a/lib/ex_public_key/ex_rsa_public_key.ex
+++ b/lib/ex_public_key/ex_rsa_public_key.ex
@@ -1,19 +1,19 @@
 defmodule ExPublicKey.RSAPublicKey do
 
   defstruct version: nil,
-            public_exponent: nil,
-            public_modulus: nil
+    public_modulus: nil,
+    public_exponent: nil
 
   @type t :: %ExPublicKey.RSAPublicKey{
     version: atom,
-    public_exponent: integer,
-    public_modulus: integer
+    public_modulus: integer,
+    public_exponent: integer
   }
 
   def from_sequence(rsa_key_seq) do
     %ExPublicKey.RSAPublicKey{} |> struct(
-      public_exponent: elem(rsa_key_seq, 1),
-      public_modulus: elem(rsa_key_seq, 2)
+      public_modulus: elem(rsa_key_seq, 1),
+      public_exponent: elem(rsa_key_seq, 2)
     )
   end
 
@@ -22,8 +22,8 @@ defmodule ExPublicKey.RSAPublicKey do
       %ExPublicKey.RSAPublicKey{} ->
         {:ok, {
           :RSAPublicKey,
-          rsa_public_key.public_exponent,
           rsa_public_key.public_modulus,
+          rsa_public_key.public_exponent
         }}
       _ ->
         {:error, "invalid ExPublicKey.RSAPublicKey: #{rsa_public_key}"}


### PR DESCRIPTION
If you load Erlang records from public_key module:
```
Erlang/OTP 19 [erts-8.1] [source-77fb4f8] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V8.1  (abort with ^G)
1> rr(public_key).
['AAControls','ACClearAttrs','AccessDescription',
 'Algorithm','AlgorithmIdentifier',
 'AlgorithmIdentifierPKCS-10','AlgorithmIdentifierPKCS-8',
 'AlgorithmIdentifierPKCS5v2-0','AlgorithmIdentifierPKSC-7',
 'AlgorithmNull','AnotherName','AttCertValidityPeriod',
 'Attribute','AttributeCertificate',
 'AttributeCertificateInfo','AttributePKCS-10',
 'AttributePKCS-7','AttributeTypeAndValue',
 'Attributes_SETOF',
 'Attributes_SETOF_valuesWithContext_SETOF',
 'AuthorityKeyIdentifier','BasicConstraints',
 'BuiltInDomainDefinedAttribute','BuiltInStandardAttributes',
 'Certificate','CertificateList','CertificationRequest',
 'CertificationRequestInfo',
 'CertificationRequestInfo_attributes_SETOF'|...]
2> #'RSAPublicKey'{}.
#'RSAPublicKey'{modulus = undefined,
                publicExponent = undefined}
3> #'RSAPrivateKey'{}.
#'RSAPrivateKey'{version = undefined,modulus = undefined,
                 publicExponent = undefined,privateExponent = undefined,
                 prime1 = undefined,prime2 = undefined,exponent1 = undefined,
                 exponent2 = undefined,coefficient = undefined,
                 otherPrimeInfos = asn1_NOVALUE}
```

You can see that modulus is always on index 1 and publicExponent on index 2. 
This is important because if you use crypto:private_decrypt/4 or crypto:public_encrypt/4 you need to pass the keys as a list [e, n, d, p1, p2, e1, e2, c] or [e, n]. 