### PR TITLE
Loads RSA keys with Passphrase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
 elixir:
-  - 1.2.6
+  - 1.3.0
 otp_release:
   - 18.2.1
 script: mix test --trace

--- a/lib/ex_public_key.ex
+++ b/lib/ex_public_key.ex
@@ -30,8 +30,8 @@ defmodule ExPublicKey do
     end
   end
 
-  def load!(file_path) do
-    case load(file_path) do
+  def load!(file_path, passphrase \\ nil) do
+    case load(file_path, passphrase) do
       {:ok, key} ->
         key
       {:error, reason} ->
@@ -47,22 +47,15 @@ defmodule ExPublicKey do
     end
   end
 
-  def loads(pem_string) do
-    pem_entries = :public_key.pem_decode(pem_string)
-    with {:ok, pem_entry} <- validate_pem_length(pem_entries),
-         {:ok, rsa_key} <- load_pem_entry(pem_entry),
-    do: sort_key_tup(rsa_key)
-  end
-
-  def loads(pem_string, passphrase) do
+  def loads(pem_string, passphrase \\ nil) do
     pem_entries = :public_key.pem_decode(pem_string)
     with {:ok, pem_entry} <- validate_pem_length(pem_entries),
          {:ok, rsa_key} <- load_pem_entry(pem_entry, passphrase),
     do: sort_key_tup(rsa_key)
   end
 
-  def loads!(pem_string) do
-    case loads(pem_string) do
+  def loads!(pem_string, passphrase \\ nil) do
+    case loads(pem_string, passphrase) do
       {:ok, key} ->
         key
       {:error, reason} ->

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ExCrypto.Mixfile do
     [app: :ex_crypto,
      version: "0.5.0",
      name: "ExCrypto",
-     elixir: ">= 1.0.0",
+     elixir: ">= 1.3.0",
      description: description(),
      package: package(),
      deps: deps(),


### PR DESCRIPTION
These methods accept an additional `passphrase` argument (defaults to `nil`), which if present, tries to decode the entry using the supplied passphrase:

 - `load`
 - `load!`
 - `loads`
 - `loads!`
 - `load_pem_entry`

Also converts the passphrase to charlist if it's a string to make it work with the underlying erlang `:public_key` module.

Closes #11.