### PR TITLE
ExPublicKey.generate_key compatibility with OTP 20.0

### DIFF
--- a/lib/ex_public_key.ex
+++ b/lib/ex_public_key.ex
@@ -314,10 +314,10 @@ defmodule ExPublicKey do
   end
 
   defp otp_has_rsa_gen_support do
-    case (to_string(Application.spec(:public_key, :vsn)) |> Float.parse) do
-      :error -> false
-      {version, _remainder} -> version >= 1.5
-    end
+    Application.spec(:public_key, :vsn)
+    |> Kernel.to_string
+    # 1.4.1 corresponds with OTP 20.0, which included crypto 4.0 that added the rsa public key generation. public_key the get an interface, too.
+    |> Version.match?(">= 1.4.1")
   end
 
   defp generate_rsa_openssl_fallback(bits) do

--- a/lib/ex_public_key.ex
+++ b/lib/ex_public_key.ex
@@ -313,16 +313,18 @@ defmodule ExPublicKey do
     Base.encode64(payload_bytes)
   end
 
+  # Erlang public_key v1.4.1 corresponds to Erlang/OTP 20.0
   defp otp_has_rsa_gen_support do
-    Application.spec(:public_key, :vsn)
+    integer_list_version = Application.spec(:public_key, :vsn)
     |> Kernel.to_string
-    # 1.4.1 corresponds with OTP 20.0, which included crypto 4.0 that added the rsa public key generation. public_key the get an interface, too.
-    |> Version.match?(">= 1.4.1")
+    |> String.split(".")
+    |> Enum.map(&Integer.parse/1)
+
+    integer_list_version >= [1, 4, 1]
   end
 
   defp generate_rsa_openssl_fallback(bits) do
     {pem_entry, _exit_code} = System.cmd("openssl", ["genrsa", to_string(bits)])
     loads(pem_entry)
   end
-
 end

--- a/lib/ex_public_key/ex_rsa_private_key.ex
+++ b/lib/ex_public_key/ex_rsa_private_key.ex
@@ -28,7 +28,7 @@ defmodule ExPublicKey.RSAPrivateKey do
 
   def from_sequence(rsa_key_seq) do
     %ExPublicKey.RSAPrivateKey{} |> struct(
-      version: elem(rsa_key_seq, 1),
+      version: maybe_convert_version_to_atom(elem(rsa_key_seq, 1)),
       public_modulus: elem(rsa_key_seq, 2),
       public_exponent: elem(rsa_key_seq, 3),
       private_exponent: elem(rsa_key_seq, 4),
@@ -61,5 +61,11 @@ defmodule ExPublicKey.RSAPrivateKey do
         {:error, "invalid ExPublicKey.RSAPrivateKey: #{inspect rsa_private_key}"}
     end
   end
+
+  # Generating a RSA key on OTP 20.0 results in a RSAPrivateKey with version 0, which is the internal number that matches to :"two-prime".
+  # Parsing this structure to PEM and then converting it back will yield a version not of 0, but of :"two-prime".
+  # This conversion ensures it is always the symbol.
+  defp maybe_convert_version_to_atom(0), do: :"two-prime"
+  defp maybe_convert_version_to_atom(version), do: version
 
 end


### PR DESCRIPTION
The initial ExCrypto implementation of generate_key by @barttenbrinke was tested against Erlang/OTP 20.1, which has slightly different internal library versions than Erlang/OTP 20.0, which introduced the generate_key feature it was built on. This PR aims to make the feature work on both versions.

I've lowered the version requirement for Erlang public_key from 1.5 to
1.4.1 (which matches OTP 20.0) and switched to Version.match?() to do proper version checking.

The internal data format for RSAPrivateKey was not consistently
handled in OTP 20.0, generating version `0`, but when encoding it as PEM and parsing it back, the version it returned was `:"two-prime"`. Based on some searching, 0 is the internal name of two-prime, and 20.1 smooths this out but 20.0 still gives the raw value.

I've considered editing `.travis.yml` to add OTP release 20.0 as a test target as well, but I'm not sure what the policy is for editing that file. My versions when testing were these:

```
# elixir --version
Erlang/OTP 20 [erts-9.0.4] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
Elixir 1.5.1
```