### PR TITLE
Implement Inspect for RSAPrivateKey

### DIFF
--- a/lib/ex_public_key/ex_rsa_private_key.ex
+++ b/lib/ex_public_key/ex_rsa_private_key.ex
@@ -1,5 +1,5 @@
 defmodule ExPublicKey.RSAPrivateKey do
-  defimpl Inspect, for: __MODULE__ do
+  defimpl Inspect do
     def inspect(_data, _opts), do: "%ExPublicKey.RSAPrivateKey{}"
   end
 

--- a/lib/ex_public_key/ex_rsa_private_key.ex
+++ b/lib/ex_public_key/ex_rsa_private_key.ex
@@ -1,4 +1,8 @@
 defmodule ExPublicKey.RSAPrivateKey do
+  defimpl Inspect, for: __MODULE__ do
+    def inspect(_data, _opts), do: "%ExPublicKey.RSAPrivateKey{}"
+  end
+
   defstruct version: nil,
             public_modulus: nil,
             public_exponent: nil,

--- a/test/ex_public_key_test.exs
+++ b/test/ex_public_key_test.exs
@@ -235,4 +235,9 @@ defmodule ExPublicKeyTest do
     recv_msg_unserialized = Poison.Parser.parse!(recv_msg_serialized)
     assert(msg == recv_msg_unserialized)
   end
+
+  test "inspecting a private key doesn't expose it", %{rsa_private_key_path: path} do
+    {:ok, priv_key} = ExPublicKey.load(path)
+    refute String.contains?(inspect(priv_key), to_string(priv_key.prime_one))
+  end
 end


### PR DESCRIPTION
This should make it less likely that it will accidentally get dumped in
a log or on a screen.