### PR TITLE
feature/2018.03.13_add-fingerprint-1

### DIFF
--- a/lib/ex_public_key.ex
+++ b/lib/ex_public_key.ex
@@ -365,7 +365,11 @@ defmodule ExPublicKey do
   end
 
   defp generate_rsa_openssl_fallback(bits) do
-    {pem_entry, _exit_code} = System.cmd("openssl", ["genrsa", to_string(bits)])
-    loads(pem_entry)
+    with {pem_entry, 0} <- System.cmd("openssl", ["genrsa", to_string(bits)]) do
+      loads(pem_entry)
+    else
+      {result, ret_code} ->
+        {:error, "result=#{result} ret_code=#{ret_code}"}
+    end
   end
 end

--- a/lib/ex_public_key/ex_rsa_private_key.ex
+++ b/lib/ex_public_key/ex_rsa_private_key.ex
@@ -90,7 +90,35 @@ defmodule ExPublicKey.RSAPrivateKey do
   # Protocols
 
   defimpl Inspect do
-    def inspect(_data, _opts), do: "%ExPublicKey.RSAPrivateKey{}"
+    import Inspect.Algebra
+
+    @doc """
+    Formats the RSAPrivateKey without exposing any private information.
+
+    example:
+    ```
+    #ExPublicKey.RSAPrivateKey<
+     fingerprint_sha256=7a:40:1c:b9:4b:b8:a5:bb:6b:98:b6:1b:8b:7a:24:8d:45:9b:e5:54
+      17:7e:66:26:7e:95:11:9d:39:14:7b:b2>
+    ```
+    """
+    def inspect(data, _opts) do
+      fp_opts = [format: :sha256, colons: true]
+
+      fp_sha256_parts_doc =
+        ExPublicKey.RSAPrivateKey.get_fingerprint(data, fp_opts)
+        |> String.split(":")
+        |> fold_doc(fn(doc, acc) -> glue(doc, ":", acc) end)
+
+      fp_sha256_doc =
+        glue("fingerprint_sha256=", "", fp_sha256_parts_doc)
+        |> group()
+        |> nest(1)
+
+      glue("#ExPublicKey.RSAPrivateKey<", "", fp_sha256_doc)
+      |> concat(">")
+      |> nest(1)
+    end
   end
 
   # Helpers

--- a/lib/ex_public_key/ex_rsa_private_key.ex
+++ b/lib/ex_public_key/ex_rsa_private_key.ex
@@ -1,8 +1,4 @@
 defmodule ExPublicKey.RSAPrivateKey do
-  defimpl Inspect do
-    def inspect(_data, _opts), do: "%ExPublicKey.RSAPrivateKey{}"
-  end
-
   defstruct version: nil,
             public_modulus: nil,
             public_exponent: nil,
@@ -90,6 +86,14 @@ defmodule ExPublicKey.RSAPrivateKey do
     get_public(rsa_private_key)
     |> ExPublicKey.RSAPublicKey.get_fingerprint(opts)
   end
+
+  # Protocols
+
+  defimpl Inspect do
+    def inspect(_data, _opts), do: "%ExPublicKey.RSAPrivateKey{}"
+  end
+
+  # Helpers
 
   # Generating a RSA key on OTP 20.0 results in a RSAPrivateKey with version 0, which is the internal number that matches to :"two-prime".
   # Parsing this structure to PEM and then converting it back will yield a version not of 0, but of :"two-prime".

--- a/lib/ex_public_key/ex_rsa_private_key.ex
+++ b/lib/ex_public_key/ex_rsa_private_key.ex
@@ -113,11 +113,11 @@ defmodule ExPublicKey.RSAPrivateKey do
       fp_sha256_doc =
         glue("fingerprint_sha256=", "", fp_sha256_parts_doc)
         |> group()
-        |> nest(1)
+        |> nest(2)
 
       glue("#ExPublicKey.RSAPrivateKey<", "", fp_sha256_doc)
       |> concat(">")
-      |> nest(1)
+      |> nest(2)
     end
   end
 

--- a/lib/ex_public_key/ex_rsa_private_key.ex
+++ b/lib/ex_public_key/ex_rsa_private_key.ex
@@ -66,6 +66,31 @@ defmodule ExPublicKey.RSAPrivateKey do
     end
   end
 
+  def decode_der(der_encoded) do
+    key_sequence = :public_key.der_decode(:RSAPrivateKey, der_encoded)
+    rsa_private_key = from_sequence(key_sequence)
+    {:ok, rsa_private_key}
+  end
+
+  def encode_der(rsa_private_key=%__MODULE__{}) do
+    with {:ok, key_sequence} <- as_sequence(rsa_private_key) do
+      der_encoded = :public_key.der_encode(:RSAPrivateKey, key_sequence)
+      {:ok, der_encoded}
+    end
+  end
+
+  def get_public(rsa_private_key=%__MODULE__{}) do
+    %ExPublicKey.RSAPublicKey{
+      public_modulus: rsa_private_key.public_modulus,
+      public_exponent: rsa_private_key.public_exponent,
+    }
+  end
+
+  def get_fingerprint(rsa_private_key=%__MODULE__{}, opts \\ []) do
+    get_public(rsa_private_key)
+    |> ExPublicKey.RSAPublicKey.get_fingerprint(opts)
+  end
+
   # Generating a RSA key on OTP 20.0 results in a RSAPrivateKey with version 0, which is the internal number that matches to :"two-prime".
   # Parsing this structure to PEM and then converting it back will yield a version not of 0, but of :"two-prime".
   # This conversion ensures it is always the symbol.

--- a/lib/ex_public_key/ex_rsa_public_key.ex
+++ b/lib/ex_public_key/ex_rsa_public_key.ex
@@ -94,11 +94,11 @@ defmodule ExPublicKey.RSAPublicKey do
       fp_sha256_doc =
         glue("fingerprint_sha256=", "", fp_sha256_parts_doc)
         |> group()
-        |> nest(1)
+        |> nest(2)
 
       glue("#ExPublicKey.RSAPublicKey<", "", fp_sha256_doc)
       |> concat(">")
-      |> nest(1)
+      |> nest(2)
     end
   end
 

--- a/lib/ex_public_key/ex_rsa_public_key.ex
+++ b/lib/ex_public_key/ex_rsa_public_key.ex
@@ -68,6 +68,40 @@ defmodule ExPublicKey.RSAPublicKey do
     |> from_der_encoded_0()
   end
 
+  # Protocols
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    @doc """
+    Formats the RSAPrivateKey and includes the SHA256 fingerprint.
+
+    example:
+    ```
+    #ExPublicKey.RSAPublicKey<
+     fingerprint_sha256=7a:40:1c:b9:4b:b8:a5:bb:6b:98:b6:1b:8b:7a:24:8d:45:9b:e5:54
+      17:7e:66:26:7e:95:11:9d:39:14:7b:b2>
+    ```
+    """
+    def inspect(data, _opts) do
+      fp_opts = [format: :sha256, colons: true]
+
+      fp_sha256_parts_doc =
+        ExPublicKey.RSAPublicKey.get_fingerprint(data, fp_opts)
+        |> String.split(":")
+        |> fold_doc(fn(doc, acc) -> glue(doc, ":", acc) end)
+
+      fp_sha256_doc =
+        glue("fingerprint_sha256=", "", fp_sha256_parts_doc)
+        |> group()
+        |> nest(1)
+
+      glue("#ExPublicKey.RSAPublicKey<", "", fp_sha256_doc)
+      |> concat(">")
+      |> nest(1)
+    end
+  end
+
   # Helpers
 
   defp add_fingerprint_colons(data, true) do

--- a/lib/ex_public_key/ex_rsa_public_key.ex
+++ b/lib/ex_public_key/ex_rsa_public_key.ex
@@ -31,4 +31,53 @@ defmodule ExPublicKey.RSAPublicKey do
         {:error, "invalid ExPublicKey.RSAPublicKey: #{rsa_public_key}"}
     end
   end
+
+  def get_fingerprint(rsa_public_key=%__MODULE__{}, opts \\ []) do
+    # parse opts
+    digest_type = Keyword.get(opts, :digest_type, :sha256)
+
+    # encode_der and hash
+    with {:ok, der_encoded} <- encode_der(rsa_public_key),
+         digest = :crypto.hash(digest_type, der_encoded),
+      do: Base.encode16(digest, case: :lower)
+  end
+
+  def encode_der(rsa_public_key=%__MODULE__{}) do
+    # hack to encode same defaults as openssl in SubjectPublicKeyInfo format
+    with {:ok, key_sequence} <- as_sequence(rsa_public_key) do
+      pem_entry = :public_key.pem_entry_encode(:SubjectPublicKeyInfo, key_sequence)
+      der_encoded =
+        :public_key.pem_encode([pem_entry])
+        |> String.trim()
+        |> String.split("\n")
+        |> Enum.filter(fn(line) -> !String.contains?(line, "-----") end)
+        |> Enum.join("")
+        |> Base.decode64!()
+      {:ok, der_encoded}
+    end
+  end
+
+  def decode_der(der_encoded, opts \\ []) do
+    # parse opts
+    format = Keyword.get(opts, :format, :SubjectPublicKeyInfo) # also supports :RSAPublicKey
+
+    # decode and parse
+    :public_key.der_decode(format, der_encoded)
+    |> from_der_encoded_0()
+  end
+
+  # Helpers
+
+  def from_der_encoded_0({:SubjectPublicKeyInfo, _, der_key}) do
+    with {:RSAPublicKey, pub_mod, pub_exp} <- :public_key.der_decode(:RSAPublicKey, der_key),
+      do: from_der_encoded_0({:RSAPublicKey, pub_mod, pub_exp})
+  end
+  def from_der_encoded_0({:RSAPublicKey, pub_mod, pub_exp}) do
+    rsa_pub_key = from_sequence({:RSAPublicKey, pub_mod, pub_exp})
+    {:ok, rsa_pub_key}
+  end
+  def from_der_encoded_0(_other) do
+    {:error, :invalid_public_key}
+  end
+
 end

--- a/test/ex_public_key_test.exs
+++ b/test/ex_public_key_test.exs
@@ -335,4 +335,28 @@ defmodule ExPublicKeyTest do
     refute String.contains?(inspect(priv_key), to_string(priv_key.prime_one))
   end
 
+  test "inspect/2", context do
+    # load the keys
+    priv_key = ExPublicKey.load!(context.rsa_private_key_path)
+    pub_key = ExPublicKey.load!(context.rsa_public_key_path)
+
+    # generate the fingerprints
+    priv_key_fp = RSAPrivateKey.get_fingerprint(priv_key, colons: true)
+    pub_key_fp = RSAPublicKey.get_fingerprint(pub_key, colons: true)
+
+    # get the string results of inspect
+    priv_key_inspect = inspect(priv_key)
+    pub_key_inspect = inspect(pub_key)
+
+    # verify private key
+    assert priv_key_inspect =~ priv_key_fp
+    assert String.starts_with?(priv_key_inspect, "#ExPublicKey.RSAPrivateKey<")
+    assert String.ends_with?(priv_key_inspect, ">")
+
+    # verify public key
+    assert pub_key_inspect =~ pub_key_fp
+    assert String.starts_with?(pub_key_inspect, "#ExPublicKey.RSAPublicKey<")
+    assert String.ends_with?(pub_key_inspect, ">")
+  end
+
 end

--- a/test/ex_public_key_test.exs
+++ b/test/ex_public_key_test.exs
@@ -203,9 +203,6 @@ defmodule ExPublicKeyTest do
 
   test "RSAPublicKey get_fingerprint/2 (sha256)", context do
     # compute sha256 fingerprint w/ openssl
-    # {rsa_public_key_fingerprint_sha256, 0} =
-    #   System.cmd("openssl", ["sha256", context.rsa_public_key_path_der])
-
     rsa_public_key_fingerprint_sha256 =
       to_charlist("openssl sha256 #{context.rsa_public_key_path_der}")
       |> :os.cmd()
@@ -220,9 +217,6 @@ defmodule ExPublicKeyTest do
 
   test "RSAPublicKey get_fingerprint/2 (md5)", context do
     # compute md5 fingerprint w/ openssl
-    # {rsa_public_key_fingerprint_md5, 0} =
-    #   System.cmd("openssl", ["md5", context.rsa_public_key_path_der])
-
     rsa_public_key_fingerprint_md5 =
       to_charlist("openssl md5 #{context.rsa_public_key_path_der}")
       |> :os.cmd()

--- a/test/ex_public_key_test.exs
+++ b/test/ex_public_key_test.exs
@@ -187,35 +187,6 @@ defmodule ExPublicKeyTest do
     assert der_encoded == rsa_public_key_der
   end
 
-  # test "RSAPublicKey encode_der (old)", context do
-  #   rsa_public_key_der = File.read!(context.rsa_public_key_path_der)
-  #   rsa_public_key = File.read!(context.rsa_public_key_path)
-  #   IO.puts("\nrsa_public_key_der=#{inspect rsa_public_key_der} byte_size=#{byte_size rsa_public_key_der}")
-  #   pem_entries = :public_key.pem_decode(rsa_public_key)
-  #   IO.puts("\npem_entries=#{inspect pem_entries}")
-
-  #   key_sequence = :public_key.der_decode(:SubjectPublicKeyInfo, rsa_public_key_der)
-  #   IO.puts("\nkey_sequence=#{inspect key_sequence}")
-
-  #   # pkix_decode = :public_key.pkix_decode_cert(rsa_public_key_der, :plain)
-  #   # IO.puts("\npkix_decode=#{inspect pkix_decode}")
-
-
-  #   # pem_entry = :public_key.pem_entry_decode(key_sequence)
-  #   # IO.puts("\npem_entry=#{inspect pem_entry}")
-
-  #   {:ok, rsa_pub_key} = ExPublicKey.load(context[:rsa_public_key_path])
-  #   IO.puts("\nrsa_pub_key=#{inspect rsa_pub_key, pretty: true}")
-  #   {:ok, rsa_pub_key_der_encoded} = RSAPublicKey.encode_der(rsa_pub_key)
-  #   IO.puts("\rsa_pub_key_der_encoded=#{inspect rsa_pub_key_der_encoded} byte_size=#{byte_size rsa_pub_key_der_encoded}")
-  #   File.write!("#{context.rsa_public_key_path_der}.gen.der", rsa_pub_key_der_encoded)
-  #   # {:ok, rsa_pub_key_from_der} = RSAPublicKey.decode_der(rsa_pub_key_der_encoded)
-  #   # assert rsa_pub_key_from_der == rsa_pub_key
-  #   {:ok, rsa_pub_key_from_der} = RSAPublicKey.decode_der(rsa_public_key_der)
-  #   assert rsa_pub_key_from_der == rsa_pub_key
-  #   assert rsa_pub_key_der_encoded == rsa_public_key_der
-  # end
-
   test "RSAPrivateKey get_fingerprint/2 (sha256)", context do
     # compute sha256 fingerprint w/ openssl
     {rsa_private_key_fingerprint_sha256, 0} =
@@ -251,18 +222,6 @@ defmodule ExPublicKeyTest do
     # verify computed value matches openssl
     rsa_public_key_fingerprint_md5 =~ fingerprint
   end
-
-  # test "RSA public_key compute fingerprint", context do
-  #   rsa_public_key_der = File.read!(context.rsa_public_key_path_der)
-  #   IO.puts("\nrsa_public_key_der=#{inspect rsa_public_key_der}")
-  #   {:ok, rsa_priv_key} = ExPublicKey.load(context[:rsa_private_key_path])
-  #   IO.puts("\nrsa_priv_key=#{inspect rsa_priv_key, pretty: true}")
-  #   {:ok, rsa_pub_key} = ExPublicKey.load(context[:rsa_public_key_path])
-  #   IO.puts("\nrsa_pub_key=#{inspect rsa_pub_key, pretty: true}")
-  #   IO.puts("\nrsa_public_key_fingerprint_sha256=#{inspect context.rsa_public_key_fingerprint_sha256}")
-  #   rsa_pub_fingerprint = RSAPublicKey.get_fingerprint(rsa_pub_key)
-  #   assert String.contains?(context.rsa_public_key_fingerprint_sha256, rsa_pub_fingerprint)
-  # end
 
   test "RSA private_key encrypt and RSA public_key decrypt", context do
     {:ok, rsa_priv_key} = ExPublicKey.load(context[:rsa_private_key_path])

--- a/test/ex_public_key_test.exs
+++ b/test/ex_public_key_test.exs
@@ -189,8 +189,10 @@ defmodule ExPublicKeyTest do
 
   test "RSAPrivateKey get_fingerprint/2 (sha256)", context do
     # compute sha256 fingerprint w/ openssl
-    {rsa_private_key_fingerprint_sha256, 0} =
-      System.cmd("openssl", ["sha256", context.rsa_private_key_path])
+    rsa_private_key_fingerprint_sha256 =
+      to_charlist("openssl sha256 #{context.rsa_private_key_path} 2> /dev/null")
+      |> :os.cmd()
+      |> to_string()
 
     {:ok, rsa_priv_key} = ExPublicKey.load(context.rsa_private_key_path)
     fingerprint = RSAPrivateKey.get_fingerprint(rsa_priv_key, format: :sha256)
@@ -201,8 +203,13 @@ defmodule ExPublicKeyTest do
 
   test "RSAPublicKey get_fingerprint/2 (sha256)", context do
     # compute sha256 fingerprint w/ openssl
-    {rsa_public_key_fingerprint_sha256, 0} =
-      System.cmd("openssl", ["sha256", context.rsa_public_key_path_der])
+    # {rsa_public_key_fingerprint_sha256, 0} =
+    #   System.cmd("openssl", ["sha256", context.rsa_public_key_path_der])
+
+    rsa_public_key_fingerprint_sha256 =
+      to_charlist("openssl sha256 #{context.rsa_public_key_path_der}")
+      |> :os.cmd()
+      |> to_string()
 
     {:ok, rsa_pub_key} = ExPublicKey.load(context.rsa_public_key_path)
     fingerprint = RSAPublicKey.get_fingerprint(rsa_pub_key, format: :sha256)
@@ -213,8 +220,13 @@ defmodule ExPublicKeyTest do
 
   test "RSAPublicKey get_fingerprint/2 (md5)", context do
     # compute md5 fingerprint w/ openssl
-    {rsa_public_key_fingerprint_md5, 0} =
-      System.cmd("openssl", ["md5", context.rsa_public_key_path_der])
+    # {rsa_public_key_fingerprint_md5, 0} =
+    #   System.cmd("openssl", ["md5", context.rsa_public_key_path_der])
+
+    rsa_public_key_fingerprint_md5 =
+      to_charlist("openssl md5 #{context.rsa_public_key_path_der}")
+      |> :os.cmd()
+      |> to_string()
 
     {:ok, rsa_pub_key} = ExPublicKey.load(context.rsa_public_key_path)
     fingerprint = RSAPublicKey.get_fingerprint(rsa_pub_key, format: :md5)
@@ -271,12 +283,10 @@ defmodule ExPublicKeyTest do
         assert false, "this should have provoked an error: #{inspect(signature)}"
 
       {:error, reason} ->
-        IO.inspect(reason)
-        assert true, "the right error was provoked: #{reason}"
+        assert true, "the right error was provoked: #{inspect reason}"
 
       {:error, error, _stack_trace} ->
-        IO.inspect(error)
-        assert false, "the wrong error was provoked: #{error.message}"
+        assert false, "the wrong error was provoked: #{inspect error}"
 
       _x ->
         # IO.inspect x


### PR DESCRIPTION
- update ExPublicKey.RSAPublicKey
    - add get_fingerprint/2
    - add encode_der/1
    - add decode_der/2
    - add optional colons in fingerprint
- update ExPublicKey.RSAPrivateKey
    - add decode_der/1
    - add encode_der/1
    - add get_public/1
    - add get_fingerprint/2
- update ExPublicKeyTest
- update ExPublicKey.RSAPrivateKey inspect/2
    - include the fingerprint
    - handle pretty printing
- add ExPublicKey.RSAPublicKey inspect/2
    - include the fingerprint
    - handle pretty printing
- update ExPublicKey
    - verify ret_code in generate_rsa_openssl_fallback/1
