### PR TITLE
Fixes #28

### DIFF
--- a/lib/ex_crypto.ex
+++ b/lib/ex_crypto.ex
@@ -385,7 +385,10 @@ defmodule ExCrypto do
   end
 
   defp _decrypt(key, initialization_vector, cipher_data, algorithm) do
-    {:ok, :crypto.block_decrypt(algorithm, key, initialization_vector, cipher_data)}
+    case :crypto.block_decrypt(algorithm, key, initialization_vector, cipher_data) do
+      :error -> {:error, "Decryption failed"}
+      plain_text -> {:ok, plain_text}
+    end
   catch
     kind, error -> normalize_error(kind, error)
   end

--- a/lib/ex_crypto.ex
+++ b/lib/ex_crypto.ex
@@ -355,7 +355,7 @@ defmodule ExCrypto do
       iex> assert(val == clear_text)
       true
   """
-  @spec decrypt(binary, binary, binary, binary, binary) :: {:ok, binary} | {:error, binary}
+  @spec decrypt(binary, binary, binary, binary, binary) :: {:ok, binary} | {:error, :decrypt_failed} | {:error, binary}
   def decrypt(key, authentication_data, initialization_vector, cipher_text, cipher_tag) do
     _decrypt(key, initialization_vector, {authentication_data, cipher_text, cipher_tag}, :aes_gcm)
   end
@@ -376,7 +376,7 @@ defmodule ExCrypto do
       iex> assert(val == clear_text)
       true
   """
-  @spec decrypt(binary, binary, binary) :: {:ok, binary} | {:error, binary}
+  @spec decrypt(binary, binary, binary) :: {:ok, binary} | {:error, :decrypt_failed} | {:error, binary}
   def decrypt(key, initialization_vector, cipher_text) do
     {:ok, padded_cleartext} = _decrypt(key, initialization_vector, cipher_text, :aes_cbc256)
     {:ok, unpad(padded_cleartext)}
@@ -386,7 +386,7 @@ defmodule ExCrypto do
 
   defp _decrypt(key, initialization_vector, cipher_data, algorithm) do
     case :crypto.block_decrypt(algorithm, key, initialization_vector, cipher_data) do
-      :error -> {:error, "Decryption failed"}
+      :error -> {:error, :decrypt_failed}
       plain_text -> {:ok, plain_text}
     end
   catch

--- a/test/ex_crypto_test.exs
+++ b/test/ex_crypto_test.exs
@@ -185,6 +185,6 @@ defmodule ExCryptoTest do
     {:ok, {_ad, payload}} = ExCrypto.encrypt(aes_256_key, a_data, iv, clear_text)
     {_c_iv, cipher_text, cipher_tag} = payload
     # decrypt
-    assert {:error, "Decryption failed"} = ExCrypto.decrypt(aes_256_key, "wrong ad", iv, cipher_text, cipher_tag)
+    assert {:error, :decrypt_failed} = ExCrypto.decrypt(aes_256_key, "wrong ad", iv, cipher_text, cipher_tag)
   end
 end

--- a/test/ex_crypto_test.exs
+++ b/test/ex_crypto_test.exs
@@ -174,4 +174,17 @@ defmodule ExCryptoTest do
 
     assert(is_binary(error_message))
   end
+
+  test "errors decrypting with bad auth data" do
+    {:ok, aes_256_key} = ExCrypto.generate_aes_key(:aes_256, :bytes)
+    {:ok, iv} = ExCrypto.rand_bytes(16)
+    clear_text = "a very secret message"
+    a_data = "the auth and associated data"
+
+    # encrypt
+    {:ok, {_ad, payload}} = ExCrypto.encrypt(aes_256_key, a_data, iv, clear_text)
+    {_c_iv, cipher_text, cipher_tag} = payload
+    # decrypt
+    assert {:error, "Decryption failed"} = ExCrypto.decrypt(aes_256_key, "wrong ad", iv, cipher_text, cipher_tag)
+  end
 end


### PR DESCRIPTION
According to the documentation, the return type for
:crypto.block_decrypt is either :error | plaintext. Handle the former
case and make sure to return an error back to the caller