### PR TITLE
reproduce possible decrypt bug

### DIFF
--- a/lib/ex_crypto.ex
+++ b/lib/ex_crypto.ex
@@ -21,11 +21,16 @@ defmodule ExCrypto do
   defp normalize_error(kind, error, key_and_iv \\ nil) do
     key_error = test_key_and_iv_bitlength(key_and_iv)
 
+    normalized_result = Exception.normalize(kind, error)
+
     cond do
       key_error ->
         key_error
 
-      %{message: message} = Exception.normalize(kind, error) ->
+      # %{term: %{message: message}} = normalized_result ->
+      #   {:error, message}
+
+      %{message: message} = normalized_result ->
         {:error, message}
 
       x = Exception.normalize(kind, error) ->

--- a/lib/ex_crypto.ex
+++ b/lib/ex_crypto.ex
@@ -27,8 +27,8 @@ defmodule ExCrypto do
       key_error ->
         key_error
 
-      # %{term: %{message: message}} = normalized_result ->
-      #   {:error, message}
+      %{term: %{message: message}} = normalized_result ->
+        {:error, message}
 
       %{message: message} = normalized_result ->
         {:error, message}

--- a/test/ex_crypto_test.exs
+++ b/test/ex_crypto_test.exs
@@ -187,4 +187,12 @@ defmodule ExCryptoTest do
     # decrypt
     assert {:error, :decrypt_failed} = ExCrypto.decrypt(aes_256_key, "wrong ad", iv, cipher_text, cipher_tag)
   end
+
+  test "errors decrypting with argument error (cipher_text)" do
+    # test for ** (MatchError) no match of right hand side value: %MatchError{term: %ArgumentError{message: "argument error"}}
+    {:ok, aes_256_key} = ExCrypto.generate_aes_key(:aes_256, :bytes)
+    {:ok, iv} = ExCrypto.rand_bytes(16)
+
+    assert {:error, "argument error"} = ExCrypto.decrypt(aes_256_key, iv, "asdasdasdads")
+  end
 end


### PR DESCRIPTION
I'm running on
```
⟩ elixir --version
Erlang/OTP 21 [erts-10.2.1] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [hipe]

Elixir 1.8.1 (compiled with Erlang/OTP 21)
```

When I pass arbitrary data to `decrypt` like: `ExCrypto.decrypt(aes_256_key, iv, "asdasdasdads")`

I receive the following error:
```
** (MatchError) no match of right hand side value: %MatchError{term: {:error, "argument error"}}
    (ex_crypto) lib/ex_crypto.ex:28: ExCrypto.normalize_error/3
```

Now, I'm not completely sure if this is intended or if this is a bug (Elixir beginner) but it seems to me that Exception.normalize/3 doesn't map this particular error as expected. 
My usecase is such that it might be possible that arbitrary data comes into the decrypt, which might not be best solution however I'd expect it to inform the caller with an error tuple and not throw.

In this PR I added a test to reproduce this. Also in ex_crypto.ex I added a cond clause to 'catch' and normalize this error.
