### PR TITLE
Fixes Base64 encoding of generated AES keys

### DIFF
--- a/lib/ex_crypto.ex
+++ b/lib/ex_crypto.ex
@@ -183,11 +183,11 @@ defmodule ExCrypto do
   @spec generate_aes_key(atom, atom) :: {:ok, binary} | {:error, binary}
   def generate_aes_key(key_type, key_format) do
     case {key_type, key_format} do
-      {:aes_128, :base64} -> rand_bytes!(16) |> url_encode64
+      {:aes_128, :base64} -> rand_bytes!(16) |> encode64
       {:aes_128, :bytes} -> rand_bytes(16)
-      {:aes_192, :base64} -> rand_bytes!(24) |> url_encode64
+      {:aes_192, :base64} -> rand_bytes!(24) |> encode64
       {:aes_192, :bytes} -> rand_bytes(24)
-      {:aes_256, :base64} -> rand_bytes!(32) |> url_encode64
+      {:aes_256, :base64} -> rand_bytes!(32) |> encode64
       {:aes_256, :bytes} -> rand_bytes(32)
       _ -> {:error, "invalid key_type/key_format"}
     end
@@ -195,6 +195,10 @@ defmodule ExCrypto do
 
   defp url_encode64(bytes_to_encode) do
     {:ok, Base.url_encode64(bytes_to_encode)}
+  end
+
+  defp encode64(bytes_to_encode) do
+    {:ok, Base.encode64(bytes_to_encode)}
   end
 
   @doc """

--- a/lib/ex_crypto.ex
+++ b/lib/ex_crypto.ex
@@ -157,7 +157,12 @@ defmodule ExCrypto do
   Returns an AES key.
 
   Accepts a `key_type` (`:aes_128`|`:aes_192`|`:aes_256`) and `key_format`
-  (`:base64`|`:bytes`) to determine type of key to produce.
+  (`:base64`|`:url_base64`|`:bytes`) to determine type of key to produce.
+
+  N.B. the key formats `:bas64` and `:url_base64` use `Base.encode64/2` and `Base.url_decode64/2`,
+  respectively. The two encoding methods will result in different outputs for some values, so
+  see the documentation for each of the `Base` functions and choose the format that is appropriate
+  to your application.
 
   ## Examples
 
@@ -169,11 +174,19 @@ defmodule ExCrypto do
       iex> assert String.length(key) == 44
       true
 
+      iex> {:ok, key} = ExCrypto.generate_aes_key(:aes_256, :url_base64)
+      iex> assert String.length(key) == 44
+      true
+
       iex> {:ok, key} = ExCrypto.generate_aes_key(:aes_192, :bytes)
       iex> assert bit_size(key) == 192
       true
 
       iex> {:ok, key} = ExCrypto.generate_aes_key(:aes_192, :base64)
+      iex> assert String.length(key) == 32
+      true
+
+      iex> {:ok, key} = ExCrypto.generate_aes_key(:aes_192, :url_base64)
       iex> assert String.length(key) == 32
       true
 
@@ -184,15 +197,22 @@ defmodule ExCrypto do
       iex> {:ok, key} = ExCrypto.generate_aes_key(:aes_128, :base64)
       iex> assert String.length(key) == 24
       true
+
+      iex> {:ok, key} = ExCrypto.generate_aes_key(:aes_128, :url_base64)
+      iex> assert String.length(key) == 24
+      true
   """
   @spec generate_aes_key(atom, atom) :: {:ok, binary} | {:error, binary}
   def generate_aes_key(key_type, key_format) do
     case {key_type, key_format} do
       {:aes_128, :base64} -> rand_bytes!(16) |> encode64
+      {:aes_128, :url_base64} -> rand_bytes!(16) |> url_encode64
       {:aes_128, :bytes} -> rand_bytes(16)
       {:aes_192, :base64} -> rand_bytes!(24) |> encode64
+      {:aes_192, :url_base64} -> rand_bytes!(24) |> url_encode64
       {:aes_192, :bytes} -> rand_bytes(24)
       {:aes_256, :base64} -> rand_bytes!(32) |> encode64
+      {:aes_256, :url_base64} -> rand_bytes!(32) |> url_encode64
       {:aes_256, :bytes} -> rand_bytes(32)
       _ -> {:error, "invalid key_type/key_format"}
     end


### PR DESCRIPTION
Prior to this change, if you selected the `:base64` format when calling
`ExCrypto.generate_aes_key/2` you would get back a string that was
encoded using `Base.url_encode64`. However, the url-encoding allows
certain characters to be included that are not strictly base 64
characters (e.g. "-" and "_"), which prevents it from working properly
when used in a context that requires strict base 64 encoding. Since the
format is called `:base64` and not something like `:base64_url`, this is
surprising behavior.

(In particular, I was trying to send the value to
[Vault](https://www.vaultproject.io) and was randomly getting back 400
errors that turned out to be happening when the generated key happened
to contain the invalid characters.)